### PR TITLE
add `main` script to package.json to be requireable

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "jshint-node compatible reporter to generate tap files (Test Anything Protocol)",
   "version": "0.0.1",
   "homepage": "https://github.com/irae/jshint-tap",
+  "main": "jshint-tap.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/irae/jshint-tap.git"


### PR DESCRIPTION
the jshint utility can accept a module directory as the --reporter option so long as the directory 'requireable'. That is, it uses the naming convention `index.js` as the main script to require (which this module does not follow). Or alternatively, uses the `main` field in package.json to explicitly name the script to be required, (which this PR adds).

Usage of this module with jshint prior to this PR:

``` shell
jshint --reporter node_modules/jshint-tap/jshint-tap.js
```

After this PR:

``` shell
jshint --reporter node_modules/jshint-tap
```
